### PR TITLE
Prevent @everyone or @here abuse

### DIFF
--- a/events/message.js
+++ b/events/message.js
@@ -62,6 +62,13 @@ module.exports = {
         }
 
         /**
+         * Check if a player attempts to abuse the bot
+         */
+        if (message.toString().includes(`@everyone`) || message.toString().includes(`@here`)) {
+            return message.reply(`You can not use mention everyone in a command!`);
+        }
+        
+        /**
          * Execute the command \o/
          */
         command.execute(client, message, args);


### PR DESCRIPTION
This additional condition could prevent bot abuse when the bot returns an argument to a player.
This condition works whether the sending player has permission to mention everyone or not.